### PR TITLE
Add additional info to selected article page, refactor how article is…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import { Route, NavLink } from 'react-router-dom'
 function App() {
 
   const [articlesPage, setArticlesPage] = useState('')
+  const [foundArticle, setFoundArticle] = useState('')
 
   useEffect(() => {
     fetch('https://api.nytimes.com/svc/topstories/v2/home.json?api-key=6dWDbpnkwGMXRHAuObTLsRvhc21hoItI').then(data => data.json()).then(data => setArticlesPage(data.results))
@@ -26,11 +27,13 @@ function App() {
         <h1 className='website-title'>News Now</h1>
       </div>
       <ArticleFilters filterFunction={selectFilter} />
-      <Route exact path='/' render={() => articlesPage ? <NewsBriefs articles={articlesPage} /> : ''} />
-      <Route exaxt path='/:title' render={({ match }) => { return <SelectedArticle selectedArticle={match.params.title} allArticles={articlesPage} /> }} />
+      <Route exact path='/' render={() => articlesPage ? <NewsBriefs articles={articlesPage} setFoundArticle={setFoundArticle} /> : ''} />
+      <Route exaxt path='/:title' render={({ match }) => { return <SelectedArticle selectedArticle={match.params.title} foundArticle={foundArticle} /> }} />
 
     </div>
   );
 }
 
 export default App;
+
+// allArticles={articlesPage}

--- a/src/NewsBreifs/NewsBriefs.js
+++ b/src/NewsBreifs/NewsBriefs.js
@@ -2,10 +2,10 @@ import React from 'react'
 import './NewsBriefs.css'
 import { NavLink } from 'react-router-dom'
 
-const NewsBriefs = ({ articles }) => {
+const NewsBriefs = ({ articles, setFoundArticle }) => {
 
     const articleCards = articles.map((article, index) => {
-        return <NavLink to={`/${article.title}`} key={`${index}`} style={{ textDecoration: 'none' }}>
+        return <NavLink to={`/${article.title}`} key={`${index}`} style={{ textDecoration: 'none' }} onClick={(() => setFoundArticle(articles.find(article => article.title === article.title)))}>
             <div className='article-card-container'>
                 <div className='article-title-box'>
                     <p className='article-title'>{article.title}</p>

--- a/src/SelectedArticle/SelectedArticle.js
+++ b/src/SelectedArticle/SelectedArticle.js
@@ -2,28 +2,50 @@ import React from 'react'
 import { useState, useEffect } from 'react'
 import Photos from '../Photos/Photos'
 
-const SelectedArticle = ({ selectedArticle, allArticles }) => {
+const SelectedArticle = ({ foundArticle }) => {
 
-    const [foundArticle, setFoundArticle] = useState('')
 
-    useEffect(() => {
-        if (selectedArticle) {
-            setFoundArticle(allArticles.find(article => article.title === selectedArticle))
+
+    const formatDate = () => {
+        let year;
+        let month;
+        let day;
+        let articleDate;
+        if (foundArticle !== '') {
+            year = foundArticle.created_date.slice(0, 4);
+            month = foundArticle.created_date.slice(5, 7)
+            day = foundArticle.created_date.slice(8, 10)
+            return articleDate = (`${month}-${day}-${year}`)
         }
 
+    }
+    console.log(formatDate())
 
-    }, [])
-
+    console.log(foundArticle.created_date)
     console.log(foundArticle)
 
-
     return (
+
         <div>
-            <a href={`${foundArticle.url}`} >{foundArticle.title}</a>
-            <p>{foundArticle.byline}</p>
-            <Photos foundArticle={foundArticle} />
+
+
+            {foundArticle ? <div> <div>
+                <a href={`${foundArticle.url}`} >{foundArticle.title}</a>
+                <p>{formatDate()}</p>
+            </div>
+                <p>{foundArticle.byline}</p>
+                <p>{foundArticle.abstract}</p>
+                <div className='article-photo-box'>
+                    {foundArticle.multimedia ? <img src={foundArticle.multimedia[1].url} /> : ''}
+                    {foundArticle.multimedia ? <p>{foundArticle.multimedia[1].caption}</p> : ''}
+                </div>  </div> : <h2>We are sorry, your article could not be found.</h2>}
+
+
+
+
         </div>
     )
+
 }
 
 export default SelectedArticle


### PR DESCRIPTION
### Description
This pull request will add error handling for going back to news now from the NYT site #3 . It will remove duplicates from the selected article page, #5 . It will also add borders for news briefs #1.

Fixes # (issue)
Adds error handling for returning from the NYT site. 

### Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x ] I have performed a self-review of my own code
- [x] My changes generate no new warnings
